### PR TITLE
refactor: update with vscode linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,3 @@ clean:
 
 run: $(BUILD_DIR)/$(TARGET)
 	$(BUILD_DIR)/$(TARGET)
-
-format:
-	clang-format -i --verbose --style={'BasedOnStyle: Google'} $(SRC_MAIN) $(SRC_UTILS)/*.* $(SRC_PROGRAMS)/*.* $(SRC_CACHE_REPLACEMENT_POLICIES)/*.*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # cacheSim
+
+**cacheSim** is a cache replacement policy simulator, that logs the cache hit (1) / miss (0) patterns of various policies of dynamic cache size.

--- a/cacheReplacementPolicies/cache.hpp
+++ b/cacheReplacementPolicies/cache.hpp
@@ -21,11 +21,12 @@
 #include "slru.hpp"
 
 template <typename R, typename T>
-struct CacheConfig {
+struct CacheConfig
+{
   // data members
   unsigned placementPolicy;
-  R *replacementPolicy = nullptr;  // we only care about the type
-  T *dataType = nullptr;           // we only care about the type
+  R *replacementPolicy = nullptr; // we only care about the type
+  T *dataType = nullptr;          // we only care about the type
   unsigned program;
   // strings
   std::string placementPolicyStr;
@@ -42,34 +43,34 @@ struct CacheConfig {
   int ramSize_bytes = 0;
 
   // units of blocks
-  int setSize_blocks;    // # of blocks in set, determined at runtime/error
-                         // handling, cannot set to const
-  int cacheSize_blocks;  // total # of blocks in cache
+  int setSize_blocks;   // # of blocks in set, determined at runtime/error
+                        // handling, cannot set to const
+  int cacheSize_blocks; // total # of blocks in cache
   // units of sets
-  int cacheSize_sets;  // # of sets in cache
+  int cacheSize_sets; // # of sets in cache
   // units of sizeOf(T)
-  int blockSize;    // # of sizeOf(T) in a block
-  int cacheSize;    // # of sizeOf(T) in cache
-  int ramSize = 0;  // # of sizeOf(T) in RAM
+  int blockSize;   // # of sizeOf(T) in a block
+  int cacheSize;   // # of sizeOf(T) in cache
+  int ramSize = 0; // # of sizeOf(T) in RAM
   // results
   unsigned hitCount = 0;
   unsigned missCount = 0;
   std::vector<std::string> pPStrings = {
-      "fully_associative",  // pP = 0 anything can go anywhere in cache - one
-                            // large set
-      "1-way_set_associative_direct_mapping",  // pP = 1 each block in main
-                                               // memory can go to only one
-                                               // block in cache
-      "2-way_set_associative",  // pP = 2 each block in main memory can go to 2
-                                // blocks in cache (1 set has two blocks)
-      "3-way_set_associative",  // pP = 3 each block in main memory can go to 2
-                                // blocks in cache (1 set has three blocks)
-      "4-way_set_associative",  // pP = 4 each block in main memory can go to 4
-                                // blocks in cache (1 set has four blocks)
+      "fully_associative",                    // pP = 0 anything can go anywhere in cache - one
+                                              // large set
+      "1-way_set_associative_direct_mapping", // pP = 1 each block in main
+                                              // memory can go to only one
+                                              // block in cache
+      "2-way_set_associative",                // pP = 2 each block in main memory can go to 2
+                                              // blocks in cache (1 set has two blocks)
+      "3-way_set_associative",                // pP = 3 each block in main memory can go to 2
+                                              // blocks in cache (1 set has three blocks)
+      "4-way_set_associative",                // pP = 4 each block in main memory can go to 4
+                                              // blocks in cache (1 set has four blocks)
       "5-way_set_associative", "6-way_set_associative", "7-way_set_associative",
       "8-way_set_associative"};
-  std::vector<std::string> rPstrings = {"FIFO", "LFU",  "LRU",
-                                        "MRU",  "SLRU", "PLRU"};
+  std::vector<std::string> rPstrings = {"FIFO", "LFU", "LRU",
+                                        "MRU", "SLRU", "PLRU"};
   std::vector<std::string> programs = {"matMul", "sort", "LSQR"};
   /* constructor */
   CacheConfig(int bS_b, int cS_b, int pP)
@@ -77,35 +78,37 @@ struct CacheConfig {
         cacheSize_bytes(cS_b),
         blockSize(bS_b / sizeof(T)),
         cacheSize(cS_b / sizeof(T)),
-        placementPolicy(pP) {
+        placementPolicy(pP)
+  {
     if (cacheSize < blockSize)
       throw std::runtime_error(
-          "cacheSize cannot be less than blockSize out of bounds");  // error
-                                                                     // checking
+          "cacheSize cannot be less than blockSize out of bounds"); // error
+                                                                    // checking
     if (cacheSize_bytes % blockSize_bytes != 0)
       throw std::runtime_error(
-          "cacheSize must be divisble by blocksize");  // error checking
+          "cacheSize must be divisble by blocksize"); // error checking
     if (cacheSize % 2 != 0)
       throw std::runtime_error(
-          "cacheSize must be divisble by 2");  // error checking
+          "cacheSize must be divisble by 2"); // error checking
     if (blockSize_bytes % 2 != 0)
       throw std::runtime_error(
-          "blocksize must be divisble by 2");  // error checking
-    if (placementPolicy != 0) {
+          "blocksize must be divisble by 2"); // error checking
+    if (placementPolicy != 0)
+    {
       if (cacheSize % placementPolicy != 0)
         throw std::runtime_error(
-            "cacheSize must be divisble by set associativity");  // error
-                                                                 // checking
+            "cacheSize must be divisble by set associativity"); // error
+                                                                // checking
     }
     if (pP > 8)
       throw std::runtime_error(
-          "placementPolicy > 8 is currently not supported ");  // error checking
+          "placementPolicy > 8 is currently not supported "); // error checking
     replacementPolicyStr = determineRp(replacementPolicy);
     placementPolicyStr = pPStrings[placementPolicy];
     setSize_blocks =
-        (pP == 0) ? (cacheSize / blockSize) : pP;        // setSize in blocks
-    cacheSize_blocks = (cacheSize / blockSize);          // cacheSize in blocks
-    cacheSize_sets = cacheSize_blocks / setSize_blocks;  // cacheSize in sets
+        (pP == 0) ? (cacheSize / blockSize) : pP;       // setSize in blocks
+    cacheSize_blocks = (cacheSize / blockSize);         // cacheSize in blocks
+    cacheSize_sets = cacheSize_blocks / setSize_blocks; // cacheSize in sets
     printf(
         "cacheSize_bytes = %d, "
         "blockSize_bytes = %d, "
@@ -118,7 +121,8 @@ struct CacheConfig {
         cacheSize_sets, blockSize, cacheSize);
   };
   // function members
-  void print() {
+  void print()
+  {
     std::cout << "***CACHE-CONFIG***" << std::endl;
     std::cout << "program = " << programStr << std::endl;
     std::cout << "placement-policy = " << placementPolicyStr << std::endl;
@@ -130,7 +134,8 @@ struct CacheConfig {
               << " blocks total)" << std::endl;
     std::cout << std::endl;
   };
-  void writeOut(int g) {
+  void writeOut(int g)
+  {
     std::string header =
         "blockSize_bytes,cacheSize_bytes,ramSize_bytes,placementPolicy,"
         "replacementPolicy,program,hits,misses,hitRatio,filename\n";
@@ -142,7 +147,8 @@ struct CacheConfig {
         std::to_string(missCount) + "," +
         std::to_string(((double)hitCount / (double)(hitCount + missCount))) +
         "," + fileoutData;
-    if (!fileout.empty()) {
+    if (!fileout.empty())
+    {
       std::ofstream report;
       std::stringstream reportName;
       reportName << fileout;
@@ -151,33 +157,52 @@ struct CacheConfig {
       report << (out + "\n");
       report.close();
       // if(hitCount==0) throw std::runtime_error("NO HITS?");
-    } else {
+    }
+    else
+    {
       throw std::runtime_error("Cache config cannot be written\n");
     };
     std::ofstream globconf(GLOBAL_CONFIG, std::ios_base::app);
-    if (globconf.is_open()) {
+    if (globconf.is_open())
+    {
       out = out + "," + std::to_string(g) + "\n";
       globconf << out;
       globconf.close();
-    } else {
+    }
+    else
+    {
       std::cout << "Unable to open " << GLOBAL_CONFIG << std::endl;
     }
   };
-  std::string determineRp(R *replacementPolicy) {
+  std::string determineRp(R *replacementPolicy)
+  {
     std::string out;
-    if (typeid(R) == typeid(FIFO<T>)) {
+    if (typeid(R) == typeid(FIFO<T>))
+    {
       out = "FIFO";
-    } else if (typeid(R) == typeid(LFU<T>)) {
+    }
+    else if (typeid(R) == typeid(LFU<T>))
+    {
       out = "LFU";
-    } else if (typeid(R) == typeid(LRU<T>)) {
+    }
+    else if (typeid(R) == typeid(LRU<T>))
+    {
       out = "LRU";
-    } else if (typeid(R) == typeid(MRU<T>)) {
+    }
+    else if (typeid(R) == typeid(MRU<T>))
+    {
       out = "MRU";
-    } else if (typeid(R) == typeid(SLRU<T>)) {
+    }
+    else if (typeid(R) == typeid(SLRU<T>))
+    {
       out = "SLRU";
-    } else if (typeid(R) == typeid(PLRU<T>)) {
+    }
+    else if (typeid(R) == typeid(PLRU<T>))
+    {
       out = "PLRU";
-    } else {
+    }
+    else
+    {
       throw std::runtime_error("unknown replacement policy");
     }
     return out;
@@ -185,41 +210,48 @@ struct CacheConfig {
 };
 
 template <class R, typename T>
-class Cache {
- public:
+class Cache
+{
+public:
   CacheConfig<R, T> &config;
-  std::vector<std::unique_ptr<R>> set;  // vector of sets
-  bool supressOut = true;               // tell the output to be quiet
+  std::vector<std::unique_ptr<R>> set; // vector of sets
+  bool supressOut = true;              // tell the output to be quiet
 
-  Cache(CacheConfig<R, T> &c, bool sO = true) : config(c) {
+  Cache(CacheConfig<R, T> &c, bool sO = true) : config(c)
+  {
     int initHashMapSize =
         (config.ramSize / config.cacheSize_sets) /
         config
-            .blockSize;  // initial size of hashmap, can grow (through allocate)
-    for (int i = 0; i < config.cacheSize_sets; ++i) {  // create vector of sets
+            .blockSize; // initial size of hashmap, can grow (through allocate)
+    for (int i = 0; i < config.cacheSize_sets; ++i)
+    { // create vector of sets
       set.emplace_back(std::make_unique<R>(config.setSize_blocks,
                                            &config.blockSize, initHashMapSize));
     };
-    if (!sO) {
+    if (!sO)
+    {
       config.print();
     };
   };
-  unsigned allocate(unsigned a) {  // increase size of ram by a
+  unsigned allocate(unsigned a)
+  { // increase size of ram by a
     config.ramSize += a;
     config.ramSize_bytes += sizeof(T) * a;
-    for (unsigned i = 0; i < config.cacheSize_sets; ++i) {
+    for (unsigned i = 0; i < config.cacheSize_sets; ++i)
+    {
       set[i]->updateRam(config.ramSize);
     };
     return config.ramSize;
   };
-  bool find(int ramIdx, T &ramData) {  // processor requests memory
+  bool find(int ramIdx, T &ramData)
+  { // processor requests memory
     if (ramIdx > config.ramSize)
-      throw std::runtime_error("ramIdx out of bounds");  // error check
+      throw std::runtime_error("ramIdx out of bounds"); // error check
     int setIndex = (ramIdx / config.blockSize) %
-                   config.cacheSize_sets;  // set index (cache scope)
+                   config.cacheSize_sets; // set index (cache scope)
     int tag = ((ramIdx / config.blockSize) - setIndex) /
-              config.cacheSize_sets;         // tag (set scope)
-    int offset = ramIdx % config.blockSize;  // offset (block scope)
+              config.cacheSize_sets;        // tag (set scope)
+    int offset = ramIdx % config.blockSize; // offset (block scope)
     // printf("numOfSets=%d, ramIdx# = %d, set# = %d, tag = %d, offset = %d\n",
     // config.cacheSize_sets, ramIdx, setIndex, tag, offset);
     return set[setIndex]->find(offset, tag, ramData);

--- a/cacheReplacementPolicies/fifo.hpp
+++ b/cacheReplacementPolicies/fifo.hpp
@@ -1,8 +1,9 @@
 #pragma once
 #include "lru.hpp"
 template <typename T>
-class FIFO : public LRU<T> {
- public:
+class FIFO : public LRU<T>
+{
+public:
   // data members
 
   /** constructor **/
@@ -11,12 +12,16 @@ class FIFO : public LRU<T> {
   // function members
   std::string name() { return "FIFO"; };
 
-  bool find(int offset, int tag, T &ramData) {  // processor requests memory
+  bool find(int offset, int tag, T &ramData)
+  { // processor requests memory
     bool hitFlag;
     Block<T> *blkPtr;
-    if (this->hit(this->hashMap[tag])) {  // CACHE HIT
+    if (this->hit(this->hashMap[tag]))
+    { // CACHE HIT
       hitFlag = true;
-    } else {  // CACHE MISS
+    }
+    else
+    { // CACHE MISS
       hitFlag = false;
       this->missLRU(offset, tag, ramData, blkPtr);
     }

--- a/cacheReplacementPolicies/lfu.hpp
+++ b/cacheReplacementPolicies/lfu.hpp
@@ -7,8 +7,9 @@
 // you should probably rebuild your LRU containers for the operations used
 // within the FreqMap
 template <typename T>
-class basicLRU {
- public:
+class basicLRU
+{
+public:
   // data members
   Block<T> *mru = nullptr;
   Block<T> *lru = nullptr;
@@ -20,7 +21,8 @@ class basicLRU {
   // basicLRU(){};
 
   // function members
-  void reset() {
+  void reset()
+  {
     mru = nullptr;
     lru = nullptr;
     moreFreq = nullptr;
@@ -28,46 +30,63 @@ class basicLRU {
     size = 0;
   };
 
-  void set(Block<T> *blkPtr) {
-    if (size == 0) {
+  void set(Block<T> *blkPtr)
+  {
+    if (size == 0)
+    {
       mru = blkPtr;
       lru = blkPtr;
       blkPtr->prev = nullptr;
       blkPtr->next = nullptr;
-    } else if (size > 0) {
-      mru->prev = blkPtr;      // blkPtr <- oldMRU ...
-      blkPtr->next = mru;      // blkPtr -> oldMRU ...
-      blkPtr->prev = nullptr;  // null <- blkPtr -> <- oldMRU ...
-      mru = blkPtr;            // null <- newMRU/blkPtr -> <- oldMRU ...
-    } else {
+    }
+    else if (size > 0)
+    {
+      mru->prev = blkPtr;     // blkPtr <- oldMRU ...
+      blkPtr->next = mru;     // blkPtr -> oldMRU ...
+      blkPtr->prev = nullptr; // null <- blkPtr -> <- oldMRU ...
+      mru = blkPtr;           // null <- newMRU/blkPtr -> <- oldMRU ...
+    }
+    else
+    {
       throw std::runtime_error("theres a problem with your basicLRU insert");
     }
     size++;
   };
 
-  void remove(Block<T> *blkPtr) {
-    if (size == 1) {  // only one element left
+  void remove(Block<T> *blkPtr)
+  {
+    if (size == 1)
+    { // only one element left
       lru = nullptr;
       mru = nullptr;
-    } else if (size > 1) {
-      if (blkPtr == lru) {          // if lru
-        lru->prev->next = nullptr;  // ... newLRU -> nullptr |  newLRU <-
-                                    // oldLRU/blkPtr -> nullptr
-        lru = lru->prev;            // new lru
-        blkPtr->prev = nullptr;     // ... newLRU -> nullptr |  nullptr <-
-                                    // oldLRU/blkPtr -> nullptr
-      } else if (blkPtr == mru) {   // if mru
-        mru->next->prev = nullptr;  // nullptr <- oldMRU/blkPtr -> newMRU |
-                                    // nullptr <- newMRU ...
-        mru = mru->next;            // new mru
+    }
+    else if (size > 1)
+    {
+      if (blkPtr == lru)
+      {                            // if lru
+        lru->prev->next = nullptr; // ... newLRU -> nullptr |  newLRU <-
+                                   // oldLRU/blkPtr -> nullptr
+        lru = lru->prev;           // new lru
+        blkPtr->prev = nullptr;    // ... newLRU -> nullptr |  nullptr <-
+                                   // oldLRU/blkPtr -> nullptr
+      }
+      else if (blkPtr == mru)
+      {                            // if mru
+        mru->next->prev = nullptr; // nullptr <- oldMRU/blkPtr -> newMRU |
+                                   // nullptr <- newMRU ...
+        mru = mru->next;           // new mru
         blkPtr->next =
-            nullptr;  // nullptr <- oldMRU/blkPtr -> nullptr | nullptr
-                      // <- newMRU ...
-      } else {        // if in middle (swap)
+            nullptr; // nullptr <- oldMRU/blkPtr -> nullptr | nullptr
+                     // <- newMRU ...
+      }
+      else
+      { // if in middle (swap)
         blkPtr->prev->next = blkPtr->next;
         blkPtr->next->prev = blkPtr->prev;
       }
-    } else {
+    }
+    else
+    {
       throw std::runtime_error("theres a problem with your basicLRU remove");
     }
     // disconnect from this LRU
@@ -78,8 +97,9 @@ class basicLRU {
 };
 
 template <typename T>
-class LFU : public Set<T> {
- public:
+class LFU : public Set<T>
+{
+public:
   /** LFU
    * Map is stores the frequencies and the corresponding blocks that have those
    * frequencies with their own replacement algorithmn (e.g. FIFO or LRU)
@@ -87,40 +107,49 @@ class LFU : public Set<T> {
 
   // data members
   std::map<unsigned, std::shared_ptr<basicLRU<T>>>
-      freqMap;  // max size == setSize
+      freqMap; // max size == setSize
   std::shared_ptr<basicLRU<T>> mfu = nullptr;
   std::shared_ptr<basicLRU<T>> lfu = nullptr;
 
   /** constructor **/
-  LFU(int sS, int *bS, int hMS) : Set<T>(sS, bS, hMS) {
+  LFU(int sS, int *bS, int hMS) : Set<T>(sS, bS, hMS)
+  {
     if (sS == 1)
       throw std::runtime_error(
           "LFU is not supported for direct mapping "
           "(doesnt make sense to implement)\n");
     std::shared_ptr<basicLRU<T>> blruPtr(new basicLRU<T>);
-    freqMap.insert({0, blruPtr});  // starting out
+    freqMap.insert({0, blruPtr}); // starting out
     lfu = blruPtr;
     mfu = blruPtr;
   };
 
   // function members
   std::string name() { return "LFU"; };
-  bool isKeyInMap(unsigned key) {
-    if (freqMap.find(key) == freqMap.end()) {
+  bool isKeyInMap(unsigned key)
+  {
+    if (freqMap.find(key) == freqMap.end())
+    {
       return false;
-    } else {
+    }
+    else
+    {
       return true;
     }
   };
 
   void insertAfter(std::shared_ptr<basicLRU<T>> bLRU,
-                   std::shared_ptr<basicLRU<T>> newbLRU) {  // direction lfu
+                   std::shared_ptr<basicLRU<T>> newbLRU)
+  { // direction lfu
     // mfu  <-head->.....<-tail-> lfu
     newbLRU->moreFreq = bLRU;
-    if (bLRU->lessFreq == nullptr) {  // LFU
+    if (bLRU->lessFreq == nullptr)
+    { // LFU
       newbLRU->lessFreq = nullptr;
       lfu = newbLRU;
-    } else {
+    }
+    else
+    {
       newbLRU->lessFreq = bLRU->lessFreq;
       bLRU->lessFreq->moreFreq = newbLRU;
     }
@@ -128,21 +157,26 @@ class LFU : public Set<T> {
   };
 
   void insertBefore(std::shared_ptr<basicLRU<T>> bLRU,
-                    std::shared_ptr<basicLRU<T>> newbLRU) {  // direction mfu
+                    std::shared_ptr<basicLRU<T>> newbLRU)
+  { // direction mfu
     // mfu  <-head->.....<-tail-> lfu
     // (before)<-moreFreq.....lessFreq->(after)
     newbLRU->lessFreq = bLRU;
-    if (bLRU->moreFreq == nullptr) {  // MFU
+    if (bLRU->moreFreq == nullptr)
+    { // MFU
       newbLRU->moreFreq = nullptr;
       mfu = newbLRU;
-    } else {
+    }
+    else
+    {
       newbLRU->moreFreq = bLRU->moreFreq;
       bLRU->moreFreq->lessFreq = newbLRU;
     }
     bLRU->moreFreq = newbLRU;
   };
 
-  void insertMFU(std::shared_ptr<basicLRU<T>> newbLRU) {
+  void insertMFU(std::shared_ptr<basicLRU<T>> newbLRU)
+  {
     // insertBeginning
     //// if we didnt initialize our list we could use commented out code
     // if (mfu == nullptr){
@@ -155,7 +189,8 @@ class LFU : public Set<T> {
     // }
   };
 
-  void insertLFU(std::shared_ptr<basicLRU<T>> newbLRU) {  // insertEnd
+  void insertLFU(std::shared_ptr<basicLRU<T>> newbLRU)
+  { // insertEnd
     // if we didnt initialize our list we could use commented out code
     // if(lfu == nullptr){
     //   insertMFU(newbLRU);
@@ -164,81 +199,98 @@ class LFU : public Set<T> {
     // }
   };
 
-  void remove(std::shared_ptr<basicLRU<T>> bLRU) {
-    if (bLRU->moreFreq == nullptr) {  // if node is MFU
+  void remove(std::shared_ptr<basicLRU<T>> bLRU)
+  {
+    if (bLRU->moreFreq == nullptr)
+    { // if node is MFU
       mfu = bLRU->lessFreq;
-    } else {
+    }
+    else
+    {
       bLRU->moreFreq->lessFreq = bLRU->lessFreq;
     }
 
-    if (bLRU->lessFreq == nullptr) {  // if node is LFU
+    if (bLRU->lessFreq == nullptr)
+    { // if node is LFU
       lfu = bLRU->moreFreq;
-    } else {
+    }
+    else
+    {
       bLRU->lessFreq->moreFreq = bLRU->moreFreq;
     }
     // node can be reset
     bLRU->reset();
   }
 
-  void missLFU(int offset, int tag, T &ramData, Block<T> *blkPtr) {
+  void missLFU(int offset, int tag, T &ramData, Block<T> *blkPtr)
+  {
     // 0 freq group is never removed!
     unsigned oldFreq;
     // map scope
-    if (this->dll.full) {      // recycling an existing cache-block
-      blkPtr = lfu->lru;       // still contains old data
-      oldFreq = blkPtr->freq;  // keep useful data
-      lfu->remove(blkPtr);     // block floating unassigned
-      blkPtr->reset();  // block scope - clear old data, updates hashmap as well
-                        // (you should change this)
-      if (freqMap[oldFreq]->size == 0) {
-        remove(freqMap[oldFreq]);  // remove old if necessary
-        if (oldFreq != 0) {        // we going to let 0 group float
+    if (this->dll.full)
+    {                         // recycling an existing cache-block
+      blkPtr = lfu->lru;      // still contains old data
+      oldFreq = blkPtr->freq; // keep useful data
+      lfu->remove(blkPtr);    // block floating unassigned
+      blkPtr->reset();        // block scope - clear old data, updates hashmap as well
+                              // (you should change this)
+      if (freqMap[oldFreq]->size == 0)
+      {
+        remove(freqMap[oldFreq]); // remove old if necessary
+        if (oldFreq != 0)
+        { // we going to let 0 group float
           // delete freqMap[oldFreq];                                  //
           // dangling ptr
-          freqMap[oldFreq] = nullptr;  // block dangling ptr
+          freqMap[oldFreq] = nullptr; // block dangling ptr
           freqMap.erase(oldFreq);
         }
       }
-    } else {  // pulling a fresh unused cache-block
-      blkPtr = &this->dll.blocks[this->dll.counter];  // new node
-      this->increment();  // next available node index
+    }
+    else
+    {                                                // pulling a fresh unused cache-block
+      blkPtr = &this->dll.blocks[this->dll.counter]; // new node
+      this->increment();                             // next available node index
     }
     // block scope
     this->updateNewBlock(offset, tag, ramData,
-                         blkPtr);  // block updated with new info
+                         blkPtr); // block updated with new info
     // map scope
     if (lfu != freqMap[0])
-      insertAfter(lfu, freqMap[0]);  // new lfu is set if necessary
+      insertAfter(lfu, freqMap[0]); // new lfu is set if necessary
     freqMap[0]->set(blkPtr);
   };
 
-  void hitLFU(int offset, int tag, T &ramData, Block<T> *blkPtr) {
+  void hitLFU(int offset, int tag, T &ramData, Block<T> *blkPtr)
+  {
     // block scope
     unsigned oldFreq = blkPtr->freq;
     blkPtr->freq++;
     unsigned newFreq = blkPtr->freq;
 
     // block/map scope
-    freqMap[oldFreq]->remove(blkPtr);  // remove block from old map entry
+    freqMap[oldFreq]->remove(blkPtr); // remove block from old map entry
 
     // we will now move block from oldFreq location to newFreq location
 
     // map scope
-    if (!isKeyInMap(newFreq)) {  // if new freqGroup doesnt exist
-      std::shared_ptr<basicLRU<T>> blru(new basicLRU<T>);  // create it
+    if (!isKeyInMap(newFreq))
+    {                                                     // if new freqGroup doesnt exist
+      std::shared_ptr<basicLRU<T>> blru(new basicLRU<T>); // create it
       freqMap.insert(
-          {newFreq, blru});  // add to map freqMap[newFreq] now exists
+          {newFreq, blru}); // add to map freqMap[newFreq] now exists
       insertBefore(
           freqMap[oldFreq],
-          freqMap[newFreq]);  // insert freqMap[newFreq] before existing
+          freqMap[newFreq]); // insert freqMap[newFreq] before existing
     }
     // our new node is already in the list, now check if the old one should be
     // removed we can remove the 0 group, but we wont "hard" delete it.
-    if (freqMap[oldFreq]->size == 0) {  // if the old one is now empty
-      remove(freqMap[oldFreq]);         // floating in space
-      if (oldFreq != 0) {               // we going to let 0 group float
+    if (freqMap[oldFreq]->size == 0)
+    {                           // if the old one is now empty
+      remove(freqMap[oldFreq]); // floating in space
+      if (oldFreq != 0)
+      { // we going to let 0 group float
         // delete freqMap[oldFreq];        // dangling ptr
-        freqMap[oldFreq] = nullptr;  // block dangling ptr
+        freqMap[oldFreq] = nullptr; // block dangling ptr
         freqMap.erase(oldFreq);
       }
     }
@@ -247,16 +299,21 @@ class LFU : public Set<T> {
     // end
   };
 
-  bool find(int offset, int tag, T &ramData) {  // processor requests memory
+  bool find(int offset, int tag, T &ramData)
+  { // processor requests memory
     bool hitFlag;
     Block<T> *blkPtr;
-    if (this->hit(this->hashMap[tag])) {  // CACHE HIT
-      hitFlag = true;                     // hit
-      if (this->dll.size != 1) {          // if not direct mapping
-        blkPtr = this->hashMap[tag];      // set the working pointer
+    if (this->hit(this->hashMap[tag]))
+    {                 // CACHE HIT
+      hitFlag = true; // hit
+      if (this->dll.size != 1)
+      {                              // if not direct mapping
+        blkPtr = this->hashMap[tag]; // set the working pointer
         hitLFU(offset, tag, ramData, blkPtr);
       }
-    } else {  // CACHE MISS
+    }
+    else
+    { // CACHE MISS
       hitFlag = false;
       missLFU(offset, tag, ramData, blkPtr);
     }

--- a/cacheReplacementPolicies/lru.hpp
+++ b/cacheReplacementPolicies/lru.hpp
@@ -2,14 +2,15 @@
 #include "set.hpp"
 
 template <typename T>
-class LRU : public Set<T> {
- public:
+class LRU : public Set<T>
+{
+public:
   /** LRU Cache Replacement Policy
    * LRU is the next block to be evicted (tail)
    * MRU is the last to be evicted (head) **/
 
   // data members
-  Block<T> lastEvicted;  // cacheline of last evicted
+  Block<T> lastEvicted; // cacheline of last evicted
 
   /** constructor **/
   LRU(int sS, int *bS, int hMS) : Set<T>(sS, bS, hMS){};
@@ -17,17 +18,22 @@ class LRU : public Set<T> {
   // function members
   std::string name() { return "LRU"; };
 
-  void hitLRU(int tag, Block<T> *blkPtr) {
+  void hitLRU(int tag, Block<T> *blkPtr)
+  {
     this->dll.remove(blkPtr);
     this->dll.insertBeginning(blkPtr);
   };
 
-  void missLRU(int offset, int tag, T &ramData, Block<T> *blkPtr) {
-    if (!this->dll.full) {                            // if cache not full
-      blkPtr = &this->dll.blocks[this->dll.counter];  // new node
-      this->increment();                              // update counter
-    } else {                                          // if cache full
-      blkPtr = this->dll.tail;                        // LRU
+  void missLRU(int offset, int tag, T &ramData, Block<T> *blkPtr)
+  {
+    if (!this->dll.full)
+    {                                                // if cache not full
+      blkPtr = &this->dll.blocks[this->dll.counter]; // new node
+      this->increment();                             // update counter
+    }
+    else
+    {                          // if cache full
+      blkPtr = this->dll.tail; // LRU
       lastEvicted = *blkPtr;
       this->dll.remove(blkPtr);
       blkPtr->reset();
@@ -36,7 +42,8 @@ class LRU : public Set<T> {
     this->dll.insertBeginning(blkPtr);
   };
 
-  bool find(int offset, int tag, T &ramData) {  // processor requests memory
+  bool find(int offset, int tag, T &ramData)
+  { // processor requests memory
     bool hitFlag;
     Block<T> *blkPtr;
     // std::cout<<"BEFORE"<<std::endl;
@@ -46,14 +53,18 @@ class LRU : public Set<T> {
     //     this->hashMap[i], this->hashMap[i]->next);
     //   }
     // };
-    if (this->hit(this->hashMap[tag])) {  // CACHE HIT
-      hitFlag = true;                     // hit
-      if (this->dll.size != 1) {  // if direct mapping, you dont need to move
-                                  // anything, it stays where it is
-        blkPtr = this->hashMap[tag];  // set the working pointer
+    if (this->hit(this->hashMap[tag]))
+    {                 // CACHE HIT
+      hitFlag = true; // hit
+      if (this->dll.size != 1)
+      {                              // if direct mapping, you dont need to move
+                                     // anything, it stays where it is
+        blkPtr = this->hashMap[tag]; // set the working pointer
         hitLRU(tag, blkPtr);
       }
-    } else {  // CACHE MISS
+    }
+    else
+    { // CACHE MISS
       hitFlag = false;
       missLRU(offset, tag, ramData, blkPtr);
     }

--- a/cacheReplacementPolicies/mru.hpp
+++ b/cacheReplacementPolicies/mru.hpp
@@ -1,8 +1,9 @@
 #pragma once
 #include "lru.hpp"
 template <typename T>
-class MRU : public LRU<T> {
- public:
+class MRU : public LRU<T>
+{
+public:
   /** MRU cache replacement policy
    * MRU is the next block to be evicted
    * LRU is the last to be evicted
@@ -15,31 +16,40 @@ class MRU : public LRU<T> {
   // function members
   std::string name() { return "MRU"; };
 
-  void missMRU(int offset, int tag, T &ramData, Block<T> *blkPtr) {
-    if (!this->dll.full) {                            // if cache not full
-      blkPtr = &this->dll.blocks[this->dll.counter];  // new node
+  void missMRU(int offset, int tag, T &ramData, Block<T> *blkPtr)
+  {
+    if (!this->dll.full)
+    {                                                // if cache not full
+      blkPtr = &this->dll.blocks[this->dll.counter]; // new node
       this->increment();
-    } else {                    // if cache full
-      blkPtr = this->dll.head;  // MRU
+    }
+    else
+    {                          // if cache full
+      blkPtr = this->dll.head; // MRU
       this->lastEvicted = *blkPtr;
       this->dll.remove(blkPtr);
-      blkPtr->reset();  // clear block data & hashmap
+      blkPtr->reset(); // clear block data & hashmap
     }
     this->updateNewBlock(offset, tag, ramData, blkPtr);
     this->dll.insertBeginning(blkPtr);
   };
 
-  bool find(int offset, int tag, T &ramData) {  // processor requests memory
+  bool find(int offset, int tag, T &ramData)
+  { // processor requests memory
     bool hitFlag;
     Block<T> *blkPtr;
-    if (this->hit(this->hashMap[tag])) {  // CACHE HIT
-      hitFlag = true;                     // hit
-      if (this->dll.size != 1) {  // if direct mapping, you dont need to move
-                                  // anything, it stays where it is
-        blkPtr = this->hashMap[tag];  // set the working pointer
-        this->hitLRU(tag, blkPtr);    // stays same
+    if (this->hit(this->hashMap[tag]))
+    {                 // CACHE HIT
+      hitFlag = true; // hit
+      if (this->dll.size != 1)
+      {                              // if direct mapping, you dont need to move
+                                     // anything, it stays where it is
+        blkPtr = this->hashMap[tag]; // set the working pointer
+        this->hitLRU(tag, blkPtr);   // stays same
       }
-    } else {  // CACHE MISS
+    }
+    else
+    { // CACHE MISS
       hitFlag = false;
       missMRU(offset, tag, ramData, blkPtr);
     }

--- a/cacheReplacementPolicies/set.hpp
+++ b/cacheReplacementPolicies/set.hpp
@@ -6,36 +6,40 @@
 
 // Doubly linked list
 template <typename T>
-struct Block {
+struct Block
+{
   // int valid = 0;
   // int cacheBlockSize;
-  unsigned freq = 0;  // only used for frequency based algs
+  unsigned freq = 0; // only used for frequency based algs
   // std::vector<T> data;
-  Block<T> *prev = nullptr;  // more recent
-  Block<T> *next = nullptr;  // less recent
-  Block<T> **tag = nullptr;  // location in main memory (POINTS TO HASHMAP)
+  Block<T> *prev = nullptr; // more recent
+  Block<T> *next = nullptr; // less recent
+  Block<T> **tag = nullptr; // location in main memory (POINTS TO HASHMAP)
   // Node<T>() { std::cout << "node is generated" << std::endl; }
   //~Node<T>() { std::cout << "node is destroyed" << std::endl; }
-  void reset() {
+  void reset()
+  {
     // data.clear();
     prev = nullptr;
     next = nullptr;
-    if (tag != nullptr) *tag = nullptr;  // update hashmap
+    if (tag != nullptr)
+      *tag = nullptr; // update hashmap
     tag = nullptr;
     freq = 0;
   };
 };
 
 template <typename T>
-struct DoublyLinkedList {
+struct DoublyLinkedList
+{
   // data members
   Block<T> *head = nullptr;
   Block<T> *tail = nullptr;
   int counter = 0;
   bool full = false;
-  const int size;  // number of blocks in dll
+  const int size; // number of blocks in dll
   std::vector<Block<T>>
-      blocks;  // abstraction of the cache in blocks sizeOf(blocks)=size
+      blocks; // abstraction of the cache in blocks sizeOf(blocks)=size
 
   /** Constructor **/
   DoublyLinkedList<T>(unsigned blockSize, unsigned size)
@@ -72,80 +76,101 @@ struct DoublyLinkedList {
   //   }
   // };
   void insertBefore(Block<T> *blk,
-                    Block<T> *newblk) {  // insert in direction head
+                    Block<T> *newblk)
+  { // insert in direction head
     // head  <-head->.....<-tail-> tail
     // (before)<-prev.....next->(after)
     newblk->next = blk;
-    if (blk == head) {  // head
+    if (blk == head)
+    { // head
       newblk->prev = nullptr;
       head = newblk;
-    } else {
+    }
+    else
+    {
       newblk->prev = blk->prev;
       blk->prev->next = newblk;
     }
     blk->prev = newblk;
   };
-  void insertBeginning(Block<T> *newblk) {  // insert at head
-    if (head == nullptr) {
+  void insertBeginning(Block<T> *newblk)
+  { // insert at head
+    if (head == nullptr)
+    {
       head = newblk;
       tail = newblk;
       newblk->prev = nullptr;
       newblk->next = nullptr;
-    } else {
+    }
+    else
+    {
       insertBefore(head, newblk);
     }
   };
-  void remove(Block<T> *blk) {
-    if (head == blk) {  // if node is head
+  void remove(Block<T> *blk)
+  {
+    if (head == blk)
+    { // if node is head
       head = blk->next;
-    } else {
+    }
+    else
+    {
       blk->prev->next = blk->next;
     }
 
-    if (tail == blk) {  // if node is tail
+    if (tail == blk)
+    { // if node is tail
       tail = blk->prev;
-    } else {
+    }
+    else
+    {
       blk->next->prev = blk->prev;
     }
   }
 };
 
 template <typename T>
-class Set {  // abstract class
- public:
+class Set
+{ // abstract class
+public:
   // data members
-  int *const blockSize;     // # of enries in block stored on cache level
-  DoublyLinkedList<T> dll;  // doubly linked list of cache blocks
+  int *const blockSize;    // # of enries in block stored on cache level
+  DoublyLinkedList<T> dll; // doubly linked list of cache blocks
   std::vector<Block<T> *>
-      hashMap;  // points to the cache (essentially a copy of the main memory)
+      hashMap; // points to the cache (essentially a copy of the main memory)
 
   /** constructor **/
   Set(int sS, int *bS, int hMS)
       : blockSize(bS), dll(*bS, sS), hashMap(hMS, nullptr){};
 
   // function members
-  bool hit(Block<T> *hashMapEntry) {
+  bool hit(Block<T> *hashMapEntry)
+  {
     return hashMapEntry != nullptr ? true : false;
   };
   void updateNewBlock(int offset, int tag, T &ramData,
-                      Block<T> *blkPtr) {  // relevant update for all sets
+                      Block<T> *blkPtr)
+  { // relevant update for all sets
     // hashmap updates
-    hashMap[tag] = blkPtr;  // update hashmap
+    hashMap[tag] = blkPtr; // update hashmap
     // block updates
-    blkPtr->tag = &hashMap[tag];  // pointing to locating in main mem
+    blkPtr->tag = &hashMap[tag]; // pointing to locating in main mem
     // T* ramPtrBeg = &ramData - offset;
     // T* ramPtrEnd = (&ramData - offset) + *blockSize;
     // blkPtr->data.assign(ramPtrBeg, ramPtrEnd);
   };
-  void increment() {
+  void increment()
+  {
     ++dll.counter;
     (dll.counter < dll.size) ? dll.full = false : dll.full = true;
   };
-  void decrement() {
+  void decrement()
+  {
     --dll.counter;
     dll.full = false;
   };
-  virtual void reset() {
+  virtual void reset()
+  {
     dll.blocks.clear();
     dll.blocks.resize(dll.size);
     std::fill(hashMap.begin(), hashMap.end(), nullptr);
@@ -158,11 +183,14 @@ class Set {  // abstract class
   virtual std::string name() = 0;
 
   // virtuals
-  virtual unsigned updateRam(int rS) {
+  virtual unsigned updateRam(int rS)
+  {
     unsigned increase = (((rS - 1) / *blockSize) + 1) -
-                        hashMap.size();  // increase in hashmap size
-    if (increase > 0) {
-      for (int i = 0; i < increase; ++i) {
+                        hashMap.size(); // increase in hashmap size
+    if (increase > 0)
+    {
+      for (int i = 0; i < increase; ++i)
+      {
         hashMap.push_back(nullptr);
       }
     }

--- a/programs/matMul.cpp
+++ b/programs/matMul.cpp
@@ -22,17 +22,22 @@ int matMulMain(C &config, int lhsX, int lhsY, int rhsX, int rhsY);
       1. All operations performed on one processor (core) with 64KiB (1024 cache
    lines) of L1d cache 2. */
 template <typename T>
-struct mat {
+struct mat
+{
   unsigned r;
   unsigned c;
   std::vector<T> m;
-  mat(unsigned rows, unsigned cols) : r(rows), c(cols) {
+  mat(unsigned rows, unsigned cols) : r(rows), c(cols)
+  {
     m.resize(rows * cols, 0);
   }
-  void print() {
+  void print()
+  {
     printf("(%dx%d)=\n[", r, c);
-    for (int e = 0; e < r * c; e++) {
-      if (e % c == 0) {
+    for (int e = 0; e < r * c; e++)
+    {
+      if (e % c == 0)
+      {
         (e == 0) ?: printf("\n ");
       };
       (e == r * c - 1) ? printf("%.3f", m[e]) : printf("%.3f ", m[e]);
@@ -43,7 +48,8 @@ struct mat {
 
 template <typename R, typename T>
 mat<T> matMul(CacheConfig<R, T> &config, mat<T> lhs, mat<T> rhs,
-              float &hitRatio) {
+              float &hitRatio)
+{
   int lhsCacheIdx, rhsCacheIdx;
   std::string lhsHitStr, rhsHitStr;
   typedef T data_t;
@@ -58,14 +64,18 @@ mat<T> matMul(CacheConfig<R, T> &config, mat<T> lhs, mat<T> rhs,
   // END REFERENCE
   CacheWrapper<replacementPolicy_t, data_t, std::vector<data_t>> L1(config);
 
-  auto lhsWrap = L1.allocate(lhs.r * lhs.c, lhs.m);  // datawrappers
-  auto rhsWrap = L1.allocate(rhs.r * rhs.c, rhs.m);  // datawrappers
+  auto lhsWrap = L1.allocate(lhs.r * lhs.c, lhs.m); // datawrappers
+  auto rhsWrap = L1.allocate(rhs.r * rhs.c, rhs.m); // datawrappers
 
-  if (lhs.c == rhs.r) {
-    for (int r = 0; r < lhs.r; r++) {
-      for (int c = 0; c < rhs.c; c++) {
+  if (lhs.c == rhs.r)
+  {
+    for (int r = 0; r < lhs.r; r++)
+    {
+      for (int c = 0; c < rhs.c; c++)
+      {
         float sum = 0;
-        for (int i = 0; i < rhs.r; i++) {
+        for (int i = 0; i < rhs.r; i++)
+        {
           // LHS matrix
           int lhsIdx = r * lhs.c + i;
           int lhsY = lhsIdx - (r * lhs.c);
@@ -90,8 +100,8 @@ mat<T> matMul(CacheConfig<R, T> &config, mat<T> lhs, mat<T> rhs,
           // END REFERENCE
 
           sum +=
-              lhsWrap[lhsIdx] * rhsWrap[rhsIdx];  // multiple reads, but assume
-                                                  // this is in the register
+              lhsWrap[lhsIdx] * rhsWrap[rhsIdx]; // multiple reads, but assume
+                                                 // this is in the register
           // printf("");
           // printf("lhs[%d][%d]=%.3f cache %s\nrhs[%d][%d]=%.3f cache %s\n",
           // lhsX, lhsY, lhs.m[lhsIdx], lhsHitStr.c_str(), rhsX, rhsY,
@@ -101,14 +111,16 @@ mat<T> matMul(CacheConfig<R, T> &config, mat<T> lhs, mat<T> rhs,
           // lhsHitStr.c_str(), rhsX, rhsY, rhsHitStr.c_str());
           // printf("---------------------------------------------------------------------------------\n");
         }
-        out.m[r * out.c + c] = sum;  // written to main memory
+        out.m[r * out.c + c] = sum; // written to main memory
       }
     }
     // printf("hitcount = %d, misscount = %d\n", L1.cache.hitCount,
     // L1.cache.missCount); hitRatio = (L1.cache.hitCount /
     // (float)(L1.cache.hitCount + L1.cache.missCount)); std::cout << "hit ratio
     // = " << hitRatio * 100 << "%\n" << std::endl;
-  } else {
+  }
+  else
+  {
     printf("Cannot perform multiplication, dimension mismatch %s(%d)\n",
            __FILE__, __LINE__);
     exit(1);
@@ -122,20 +134,23 @@ mat<T> matMul(CacheConfig<R, T> &config, mat<T> lhs, mat<T> rhs,
 //
 template <typename R, typename T>
 int matMulMain(CacheConfig<R, T> &config, int lhsX, int lhsY, int rhsX,
-               int rhsY) {
+               int rhsY)
+{
   float hitRatio;
   typedef T matType_t;
-  mat<matType_t> lhs(lhsX, lhsY);  // too small
-  mat<matType_t> rhs(rhsX, rhsY);  // too small
+  mat<matType_t> lhs(lhsX, lhsY); // too small
+  mat<matType_t> rhs(rhsX, rhsY); // too small
   std::random_device dev;
   std::mt19937 rng(dev());
   std::uniform_int_distribution<std::mt19937::result_type> dist6(
-      1, 25);  // distribution in range [1, 6]
-  for (int i = 0; i < rhs.r * rhs.c; ++i) {
+      1, 25); // distribution in range [1, 6]
+  for (int i = 0; i < rhs.r * rhs.c; ++i)
+  {
     rhs.m[i] = dist6(rng);
     // std::cout << &rhs.m[i] << std::endl;
   };
-  for (int i = 0; i < lhs.r * lhs.c; ++i) {
+  for (int i = 0; i < lhs.r * lhs.c; ++i)
+  {
     lhs.m[i] = dist6(rng);
     // std::cout << &lhs.m[i] << std::endl;
   };

--- a/programs/matMul.hpp
+++ b/programs/matMul.hpp
@@ -31,7 +31,8 @@ int matMulMain(CacheConfig<R, T> &config, int lhsX, int lhsY, int rhsX,
 // };
 template <typename R, typename T>
 void matMulWrapper(CacheConfig<R, T> &config, int lhsX, int lhsY, int rhsX,
-                   int rhsY) {
+                   int rhsY)
+{
   config.program = 0;
   config.programStr = config.programs[config.program];
   config.print();

--- a/programs/sort.hpp
+++ b/programs/sort.hpp
@@ -15,16 +15,19 @@ int sortMain(C &config);
 
 // R = replacement policy type, T = data type
 template <typename R, typename T>
-struct sortWrapper {
+struct sortWrapper
+{
   CacheConfig<R, T> &config;
-  sortWrapper(CacheConfig<R, T> &c, int N) : config(c) {
+  sortWrapper(CacheConfig<R, T> &c, int N) : config(c)
+  {
     config.program = 1;
     config.programStr = config.programs[config.program];
     config.print();
     int out = sortMain<R, T>(config);
     // config.writeOut();
   };
-  void run() {
+  void run()
+  {
     config.program = 1;
     config.programStr = config.programs[config.program];
     config.print();
@@ -34,35 +37,46 @@ struct sortWrapper {
 };
 
 template <typename T>
-void writeArray(int rangeLow, int rangeHigh, int dim, std::string dest) {
+void writeArray(int rangeLow, int rangeHigh, int dim, std::string dest)
+{
   std::random_device rd;
   std::mt19937 mt(rd());
   std::uniform_real_distribution<double> dist(rangeLow, rangeHigh);
   std::vector<T> arr;
-  for (int i = 0; i < dim; ++i) {
+  for (int i = 0; i < dim; ++i)
+  {
     arr.push_back(dist(mt));
   };
   std::ofstream destStream(dest);
-  if (destStream.is_open()) {
-    for (int i = 0; i < dim; i++) {
+  if (destStream.is_open())
+  {
+    for (int i = 0; i < dim; i++)
+    {
       destStream << arr[i] << "\n";
     }
     destStream.close();
-  } else {
+  }
+  else
+  {
     std::cout << "Unable to open file";
   }
 };
 
 template <typename T>
-void readArray(std::string dest, std::vector<T> &out) {
+void readArray(std::string dest, std::vector<T> &out)
+{
   std::ifstream file(dest);
-  if (file.good()) {
+  if (file.good())
+  {
     double i = 0;
-    while (file >> i) {
+    while (file >> i)
+    {
       out.push_back(i);
     }
     file.close();
-  } else {
+  }
+  else
+  {
     std::runtime_error("error!");
   }
 };
@@ -71,21 +85,25 @@ void deleteArray(std::string dest) { std::remove(dest.c_str()); };
 
 // R = replacement policy type, T = data type
 template <typename R, typename T>
-int sortMain(CacheConfig<R, T> &config) {
+int sortMain(CacheConfig<R, T> &config)
+{
   typedef T dataType_t;
   typedef R replacementPolicy_t;
   std::vector<T> values_to_sort;
   readArray(TEMP_SORT_FILE,
-            values_to_sort);  // requires writeArray to first be called
+            values_to_sort); // requires writeArray to first be called
   CacheWrapper<R, T, std::vector<T>> L1(config);
   std::cout << "vectsize " << values_to_sort.size() << std::endl;
   auto values_to_sort_wrapper =
       L1.allocate(values_to_sort.size(), values_to_sort);
   // bubble sort
   dataType_t temp;
-  for (int i = 0; i < values_to_sort.size(); ++i) {
-    for (int j = i + 1; j < values_to_sort.size(); ++j) {
-      if (values_to_sort_wrapper[j] < values_to_sort_wrapper[i]) {
+  for (int i = 0; i < values_to_sort.size(); ++i)
+  {
+    for (int j = i + 1; j < values_to_sort.size(); ++j)
+    {
+      if (values_to_sort_wrapper[j] < values_to_sort_wrapper[i])
+      {
         temp = values_to_sort_wrapper[i];
         values_to_sort[i] = values_to_sort_wrapper[j];
         values_to_sort[j] = temp;

--- a/utils/logger.hpp
+++ b/utils/logger.hpp
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #include <filesystem>
-//#include <experimental/filesystem>
+// #include <experimental/filesystem>
 #include <fstream>
 #include <random>
 #include <sstream>
@@ -14,13 +14,15 @@
 #include "utils.hpp"
 
 template <class Q>
-struct Logger {
+struct Logger
+{
   // data memebers
   Q &cache;
   std::string fileout_data;
   std::string fileout_config;
   /** constructor **/
-  Logger(Q &c) : cache(c) {
+  Logger(Q &c) : cache(c)
+  {
     /** Prepare report */
     std::ofstream report;
     std::stringstream reportName;
@@ -40,10 +42,12 @@ struct Logger {
     std::filesystem::path outData{directoryout_data};
     std::filesystem::file_status s = std::filesystem::file_status{};
 
-    if (!std::filesystem::exists(outData)) {
+    if (!std::filesystem::exists(outData))
+    {
       std::filesystem::create_directories(directoryout_data);
     };
-    if (!std::filesystem::exists(outConfig)) {
+    if (!std::filesystem::exists(outConfig))
+    {
       std::filesystem::create_directories(directoryout_config);
     };
 
@@ -54,21 +58,27 @@ struct Logger {
   };
 
   // operators
-  bool operator()(std::string s) {
+  bool operator()(std::string s)
+  {
     bool success = writeToCSV(fileout_data, s);
-    if (!success) throw std::runtime_error("cannot write to logfile");
+    if (!success)
+      throw std::runtime_error("cannot write to logfile");
     return success;
   };
 
   // function members
-  bool writeToCSV(std::string dest, std::string input) {
+  bool writeToCSV(std::string dest, std::string input)
+  {
     std::ofstream report(dest, std::ios_base::app);
     bool success = false;
-    if (report.is_open()) {
+    if (report.is_open())
+    {
       report << input;
       report.close();
       success = true;
-    } else {
+    }
+    else
+    {
       std::cout << "Unable to open file";
       success = false;
     }
@@ -76,12 +86,16 @@ struct Logger {
   };
   void demo_exists(
       const std::filesystem::path &p,
-      std::filesystem::file_status s = std::filesystem::file_status{}) {
+      std::filesystem::file_status s = std::filesystem::file_status{})
+  {
     bool out;
     if (std::filesystem::status_known(s) ? std::filesystem::exists(s)
-                                         : std::filesystem::exists(p)) {
+                                         : std::filesystem::exists(p))
+    {
       out = true;
-    } else {
+    }
+    else
+    {
       out = false;
     }
   };

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -15,7 +15,8 @@ const extern std::string GLOBAL_CONFIG =
     "results/" + NOW + "/" + NOW + "_globalconfig.csv";
 const extern std::string TEMP_SORT_FILE = "sorttemp.txt";
 
-std::string timeNowString() {
+std::string timeNowString()
+{
   auto now = std::chrono::system_clock::now();
   std::time_t now_time = std::chrono::system_clock::to_time_t(now);
   tm t = *localtime(&now_time);
@@ -33,7 +34,8 @@ std::string timeNowString() {
   return out;
 };
 
-std::string unixTimeString() {
+std::string unixTimeString()
+{
   uint64_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch())
                     .count();
@@ -41,25 +43,31 @@ std::string unixTimeString() {
   return out;
 };
 
-void initGlobalConfig() {
+void initGlobalConfig()
+{
   std::string dir_results = "results/";
   std::string directoryout = dir_results + NOW;
   std::experimental::filesystem::path path_results{dir_results};
   std::experimental::filesystem::path out{directoryout};
-  if (!std::experimental::filesystem::exists(path_results)) {
+  if (!std::experimental::filesystem::exists(path_results))
+  {
     std::experimental::filesystem::create_directory(dir_results);
   };
-  if (!std::experimental::filesystem::exists(out)) {
+  if (!std::experimental::filesystem::exists(out))
+  {
     std::experimental::filesystem::create_directory(directoryout);
   };
   std::ofstream report(GLOBAL_CONFIG, std::ios_base::app);
   std::string input =
       "blockSize_bytes,cacheSize_bytes,ramSize_bytes,placementPolicy,"
       "replacementPolicy,program,hits,misses,hitRatio,filename,group\n";
-  if (report.is_open()) {
+  if (report.is_open())
+  {
     report << input;
     report.close();
-  } else {
+  }
+  else
+  {
     std::cout << "Unable to open file " << GLOBAL_CONFIG << std::endl;
   }
 };

--- a/utils/wrappers.hpp
+++ b/utils/wrappers.hpp
@@ -9,14 +9,17 @@
 #include "utils.hpp"
 
 template <typename X>
-struct LoggerWrapper {
-  X &cache;       // one cache
-  Logger<X> log;  // one log per cache
-  LoggerWrapper(X &c) : cache(c), log(c) {
+struct LoggerWrapper
+{
+  X &cache;      // one cache
+  Logger<X> log; // one log per cache
+  LoggerWrapper(X &c) : cache(c), log(c)
+  {
     cache.config.fileoutData = log.fileout_data;
     cache.config.fileout = log.fileout_config;
   };
-  std::string operator()(std::string s) {
+  std::string operator()(std::string s)
+  {
     // std::chrono::milliseconds ms = std::chrono::duration_cast<
     // std::chrono::milliseconds >(
     // std::chrono::system_clock::now().time_since_epoch());
@@ -28,21 +31,26 @@ struct LoggerWrapper {
 };
 
 template <typename C, typename T, typename V>
-struct DataWrapper {
+struct DataWrapper
+{
   int offset;
-  V &dataset;             // reference to dataset
-  C &cache;               // reference to cache in cachewrapper
-  LoggerWrapper<C> &log;  // reference to logger in cachewrapper
+  V &dataset;            // reference to dataset
+  C &cache;              // reference to cache in cachewrapper
+  LoggerWrapper<C> &log; // reference to logger in cachewrapper
   DataWrapper(int o, V &ds, C &c, LoggerWrapper<C> &l)
       : offset(o), dataset(ds), log(l), cache(c){};
-  T operator[](int lIdx) {
+  T operator[](int lIdx)
+  {
     unsigned gIdx = offset + lIdx;
     bool temp = cache.find(gIdx, dataset[lIdx]);
     std::string out = (temp) ? "1" : "0";
     // log(out);
-    if (temp) {
+    if (temp)
+    {
       ++cache.config.hitCount;
-    } else {
+    }
+    else
+    {
       ++cache.config.missCount;
     }
     log(out);
@@ -51,12 +59,14 @@ struct DataWrapper {
 };
 
 template <typename R, typename T, typename V>
-struct CacheWrapper {
+struct CacheWrapper
+{
   typedef Cache<R, T> CacheType;
-  CacheType cache;               // one cache
-  LoggerWrapper<CacheType> log;  // one log per cache
+  CacheType cache;              // one cache
+  LoggerWrapper<CacheType> log; // one log per cache
   CacheWrapper(CacheConfig<R, T> &c) : cache(c), log(cache){};
-  DataWrapper<CacheType, T, V> allocate(unsigned a, V &v) {
+  DataWrapper<CacheType, T, V> allocate(unsigned a, V &v)
+  {
     unsigned tempBaseLine = cache.config.ramSize;
     DataWrapper<CacheType, T, V> data(cache.config.ramSize, v, cache, log);
     cache.allocate(a);


### PR DESCRIPTION
I was using clang-format before, its much more convenient to lint using vscode's built in linter. I dont love the format, but it simplifies a lot here.